### PR TITLE
[-] MO : Modif smarty assignments if root parent selected

### DIFF
--- a/blockcategories.php
+++ b/blockcategories.php
@@ -127,23 +127,26 @@ class BlockCategories extends Module
 	{
 		if (is_null($id_category))
 			$id_category = $this->context->shop->getCategory();
-
 		$children = array();
 		if (isset($resultParents[$id_category]) && count($resultParents[$id_category]) && ($maxDepth == 0 || $currentDepth < $maxDepth))
 			foreach ($resultParents[$id_category] as $subcat)
 				$children[] = $this->getTree($resultParents, $resultIds, $maxDepth, $subcat['id_category'], $currentDepth + 1);
-
-		if (!isset($resultIds[$id_category]))
-			return false;
-
+		if (isset($resultIds[$id_category])) 
+		{
+			$link = $this->context->link->getCategoryLink($id_category, $resultIds[$id_category]['link_rewrite']);
+			$name = $resultIds[$id_category]['name'];
+			$desc = $resultIds[$id_category]['description'];
+		}
+		else
+			$link = $name = $desc = '';
+			
 		$return = array(
 			'id' => $id_category,
-			'link' => $this->context->link->getCategoryLink($id_category, $resultIds[$id_category]['link_rewrite']),
-			'name' =>  $resultIds[$id_category]['name'],
-			'desc'=>  $resultIds[$id_category]['description'],
+			'link' => $link,
+			'name' => $name,
+			'desc'=> $desc,
 			'children' => $children
 		);
-
 		return $return;
 	}
 


### PR DESCRIPTION
Today, when you are on a product page, if root is selected in the blockcategory settings, this block is not displayed.