### PR TITLE
[*] FO: Use category name for category menu link title

### DIFF
--- a/blockcategories.php
+++ b/blockcategories.php
@@ -135,16 +135,15 @@ class BlockCategories extends Module
 		{
 			$link = $this->context->link->getCategoryLink($id_category, $resultIds[$id_category]['link_rewrite']);
 			$name = $resultIds[$id_category]['name'];
-			$desc = $resultIds[$id_category]['description'];
 		}
 		else
-			$link = $name = $desc = '';
+			$link = $name = '';
 			
 		$return = array(
 			'id' => $id_category,
 			'link' => $link,
 			'name' => $name,
-			'desc'=> $desc,
+			'desc'=> $name,
 			'children' => $children
 		);
 		return $return;
@@ -215,7 +214,7 @@ class BlockCategories extends Module
 			$resultIds = array();
 			$resultParents = array();
 			$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-			SELECT c.id_parent, c.id_category, cl.name, cl.description, cl.link_rewrite
+			SELECT c.id_parent, c.id_category, cl.name, cl.link_rewrite
 			FROM `'._DB_PREFIX_.'category` c
 			INNER JOIN `'._DB_PREFIX_.'category_lang` cl ON (c.`id_category` = cl.`id_category` AND cl.`id_lang` = '.(int)$this->context->language->id.Shop::addSqlRestrictionOnLang('cl').')
 			INNER JOIN `'._DB_PREFIX_.'category_shop` cs ON (cs.`id_category` = c.`id_category` AND cs.`id_shop` = '.(int)$this->context->shop->id.')
@@ -293,7 +292,7 @@ class BlockCategories extends Module
 			// Get all groups for this customer and concatenate them as a string: "1,2,3..."
 			$groups = implode(', ', Customer::getGroupsStatic((int)$this->context->customer->id));
 			if (!$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-				SELECT DISTINCT c.id_parent, c.id_category, cl.name, cl.description, cl.link_rewrite
+				SELECT DISTINCT c.id_parent, c.id_category, cl.name, cl.link_rewrite
 				FROM `'._DB_PREFIX_.'category` c
 				'.Shop::addSqlAssociation('category', 'c').'
 				LEFT JOIN `'._DB_PREFIX_.'category_lang` cl ON (c.`id_category` = cl.`id_category` AND cl.`id_lang` = '.(int)$this->context->language->id.Shop::addSqlRestrictionOnLang('cl').')

--- a/category-tree-branch.tpl
+++ b/category-tree-branch.tpl
@@ -25,7 +25,7 @@
 
 <li class="category_{$node.id}{if isset($last) && $last == 'true'} last{/if}">
 	<a href="{$node.link|escape:'html':'UTF-8'}" {if isset($currentCategoryId) && $node.id == $currentCategoryId}class="selected"{/if}
-		title="{$node.desc|strip_tags|trim|truncate:255:'...'|escape:'html':'UTF-8'}">{$node.name|escape:'html':'UTF-8'}</a>
+		title="{$node.name|escape:'html':'UTF-8'}">{$node.name|escape:'html':'UTF-8'}</a>
 	{if $node.children|@count > 0}
 		<ul>
 		{foreach from=$node.children item=child name=categoryTreeBranch}


### PR DESCRIPTION
I know this will be up for debate, but basically category description (length 255) is a total overkill for category menu item links. I've asked a couple of SEO people and they all said that category name for title is ok, while category description is not. This text is placed here involuntarily and may not suit the category link.

As far as perfomance goes, fetching category descriptions for deep category tree is also resource intensive.

P.S. I kept 'desc' column for backwards compat.