### PR TITLE
[-]MO:Fix wrong regex in blockcategories thumbnails list

### DIFF
--- a/controllers/admin/AdminBlockCategoriesController.php
+++ b/controllers/admin/AdminBlockCategoriesController.php
@@ -61,7 +61,7 @@ class AdminBlockCategoriesController extends ModuleAdminController
 			foreach ($files as $file) {
 				$matches = array();
 
-				if (preg_match('/'.$category->id.'-([0-9])?_thumb.jpg/i', $file, $matches) === 1)
+				if (preg_match('/^'.$category->id.'-([0-9])?_thumb.jpg/i', $file, $matches) === 1)
 					$assigned_keys[] = (int)$matches[1];
 			}
 


### PR DESCRIPTION
The regex was not correct : for example if you had a category with the id 23 with already 3 thumbnails, you couldn't upload thumbnails for the category with the id 3.